### PR TITLE
Revise builds for 4.1.x versions back to 4.1.8 and include here

### DIFF
--- a/4.1.10/Dockerfile
+++ b/4.1.10/Dockerfile
@@ -1,0 +1,75 @@
+FROM postgres:9.6
+MAINTAINER Michael J. Stealey <michael.j.stealey@gmail.com>
+
+# set user/group IDs for irods account
+RUN groupadd -r irods --gid=998 \
+    && useradd -r -g irods -d /var/lib/irods --uid=998 irods \
+    && mv /docker-entrypoint.sh /postgres-docker-entrypoint.sh
+
+# Prerequisites for iRODS v.4.1.10
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    sudo \
+    curl \
+    libfuse2 \
+    libjson-perl \
+    python-psutil \
+    python-requests \
+    lsof \
+    python-jsonschema \
+    unixodbc \
+    odbc-postgresql \
+    super \
+    jq
+
+# Install iRODS v.4.1.10
+RUN curl ftp://ftp.renci.org/pub/irods/releases/4.1.10/ubuntu14/irods-icat-4.1.10-ubuntu14-x86_64.deb -o irods-icat.deb \
+    && curl ftp://ftp.renci.org/pub/irods/releases/4.1.10/ubuntu14/irods-database-plugin-postgres-1.10-ubuntu14-x86_64.deb -o irods-database.deb \
+    && sudo dpkg -i irods-icat.deb irods-database.deb \
+    && sudo apt-get -f install \
+    && rm irods-icat.deb irods-database.deb
+
+# default iRODS env
+ENV IRODS_SERVICE_ACCOUNT_NAME=irods
+ENV IRODS_SERVICE_ACCOUNT_GROUP=irods
+ENV IRODS_DATABASE_SERVER_HOSTNAME=localhost
+ENV IRODS_DATABASE_SERVER_PORT=5432
+ENV IRODS_DATABASE_NAME=ICAT
+ENV IRODS_DATABASE_USER_NAME=irods
+ENV IRODS_DATABASE_PASSWORD=temppassword
+ENV IRODS_ZONE_NAME=tempZone
+ENV IRODS_PORT=1247
+ENV IRODS_PORT_RANGE_BEGIN=20000
+ENV IRODS_PORT_RANGE_END=20199
+ENV IRODS_CONTROL_PLANE_PORT=1248
+ENV IRODS_SCHEMA_VALIDATION=https://schemas.irods.org/configuration
+ENV IRODS_SERVER_ADMINISTRATOR_USER_NAME=rods
+ENV IRODS_SERVER_ZONE_KEY=TEMPORARY_zone_key
+ENV IRODS_SERVER_NEGOTIATION_KEY=TEMPORARY_32byte_negotiation_key
+ENV IRODS_CONTROL_PLANE_KEY=TEMPORARY__32byte_ctrl_plane_key
+ENV IRODS_SERVER_ADMINISTRATOR_PASSWORD=rods
+ENV IRODS_VAULT_DIRECTORY=/var/lib/irods/iRODS/Vault
+# UID / GID settings
+ENV UID_POSTGRES=999
+ENV GID_POSTGRES=999
+ENV UID_IRODS=998
+ENV GID_IRODS=998
+
+# create postgresql.tar.gz
+RUN cd /var/lib/postgresql/data \
+    && tar -czvf /postgresql.tar.gz . \
+    && cd /
+
+# create irods.tar.gz
+RUN cd /var/lib/irods \
+    && tar -czvf /irods.tar.gz . \
+    && cd /
+
+COPY ./docker-entrypoint.sh /irods-docker-entrypoint.sh
+VOLUME /var/lib/irods /etc/irods /var/lib/postgresql/data
+
+EXPOSE $IRODS_PORT $IRODS_CONTROL_PLANE_PORT $IRODS_PORT_RANGE_BEGIN-$IRODS_PORT_RANGE_END
+ENTRYPOINT ["/irods-docker-entrypoint.sh"]
+WORKDIR "/var/lib/irods"
+
+CMD ["-i", "run_irods"]

--- a/4.1.10/docker-entrypoint.sh
+++ b/4.1.10/docker-entrypoint.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -e
+
+IRODS_CONFIG_FILE=/irods.config
+INIT=false
+EXISTING=false
+USAGE=false
+VERBOSE=false
+RUN_IRODS=false
+
+_update_uid_gid() {
+    # if UID_POSTGRES = UID_IRODS, exit with error message
+    if [[ ${UID_POSTGRES} = ${UID_IRODS} ]]; then
+        echo "ERROR: user irods and user postgres cannot have same UID!!!"
+        exit 1;
+    else
+    # if UID_POSTGRES != UID_IRODS, reassign individual UIDs
+        if [[ ${UID_IRODS} = 999 ]]; then
+            gosu root usermod -u 1999 irods
+        fi
+        gosu root usermod -u ${UID_POSTGRES} postgres
+        gosu root usermod -u ${UID_IRODS} irods
+    fi
+    # if GID_POSTGRES = GID_IRODS, reset GID_POSTGRES=GID_IRODS-1 and use GID_IRODS group permissions
+    if [[ ${GID_POSTGRES} = ${GID_IRODS} ]]; then
+        gosu root groupmod -g ${GID_IRODS} irods
+        gosu root usermod -a -G ${GID_IRODS} postgres
+        gosu root chown -R postgres:irods /var/lib/postgresql
+        gosu root chown -R irods:irods /var/lib/irods
+        gosu root chown -R irods:irods /etc/irods
+    else
+    # if GID_POSTGRES != GID_IRODS, reassign individual GIDs
+        if [[ ${GID_IRODS} = 999 ]]; then
+            gosu root groupmod -g 1999 irods
+        fi
+        gosu root groupmod -g ${GID_POSTGRES} postgres
+        gosu root groupmod -g ${GID_IRODS} irods
+        gosu root chown -R postgres:postgres /var/lib/postgresql
+        gosu root chown -R irods:irods /var/lib/irods
+        gosu root chown -R irods:irods /etc/irods
+     fi
+}
+
+_set_postgres_params() {
+    # set postgres-docker-entrypoint.sh variables to coincide with iRODS variables unless explicitly defined
+    if [[ -z "${POSTGRES_PASSWORD}" ]]; then
+        gosu root sed -i 's/POSTGRES_PASSWORD/IRODS_DATABASE_PASSWORD/g' /postgres-docker-entrypoint.sh
+    fi
+    if [[ -z "${POSTGRES_USER}" ]]; then
+        gosu root sed -i 's/POSTGRES_USER/IRODS_DATABASE_USER_NAME/g' /postgres-docker-entrypoint.sh
+    fi
+    if [[ -z "${POSTGRES_DB}" ]]; then
+        gosu root sed -i 's/POSTGRES_DB/IRODS_DATABASE_NAME/g' /postgres-docker-entrypoint.sh
+    fi
+}
+
+_postgresql_tgz() {
+    if [ -z "$(ls -A /var/lib/postgresql/data)" ]; then
+        gosu root cp /postgresql.tar.gz /var/lib/postgresql/data/postgresql.tar.gz
+        cd /var/lib/postgresql/data
+        if $VERBOSE; then
+            echo "!!! populating /var/lib/postgresql/data with initial contents !!!"
+            gosu root tar -zxvf postgresql.tar.gz
+        else
+            gosu root tar -zxf postgresql.tar.gz
+        fi
+        cd /
+        gosu root rm -f /var/lib/postgresql/data/postgresql.tar.gz
+    fi
+}
+
+_irods_tgz() {
+    if [ -z "$(ls -A /var/lib/irods)" ]; then
+        gosu root cp /irods.tar.gz /var/lib/irods/irods.tar.gz
+        cd /var/lib/irods/
+        if $VERBOSE; then
+            echo "!!! populating /var/lib/irods with initial contents !!!"
+            gosu root tar -zxvf irods.tar.gz
+        else
+            gosu root tar -zxf irods.tar.gz
+        fi
+        cd /
+        gosu root rm -f /var/lib/irods/irods.tar.gz
+    fi
+}
+
+_generate_config() {
+    local OUTFILE=/irods.config
+    echo "${IRODS_SERVICE_ACCOUNT_NAME}" > $OUTFILE
+    echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> $OUTFILE
+    echo "${IRODS_ZONE_NAME}" >> $OUTFILE
+    echo "${IRODS_PORT}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_BEGIN}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_END}" >> $OUTFILE
+    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
+    echo "${IRODS_SERVER_ZONE_KEY}" >> $OUTFILE
+    echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_KEY}" >> $OUTFILE
+    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
+    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+}
+
+_usage() {
+    echo "Usage: ${0} [-h] [-ix run_irods] [-v] [arguments]"
+    echo " "
+    echo "options:"
+    echo "-h                    show brief help"
+    echo "-i run_irods          initialize iRODS 4.1.10 provider"
+    echo "-x run_irods          use existing iRODS 4.1.10 provider files"
+    echo "-v                    verbose output"
+    echo ""
+    echo "Example:"
+    echo "  $ docker run --rm mjstealey/irods-provider-postgres:4.1.10 -h           # show help"
+    echo "  $ docker run -d mjstealey/irods-provider-postgres:4.1.10 -i run_irods   # init with default settings"
+    echo ""
+    exit 0
+}
+
+while getopts hixv opt; do
+  case "${opt}" in
+    h)      USAGE=true ;;
+    i)      INIT=true && echo "Initialize iRODS provider";;
+    x)      EXISTING=true && echo "Use existing iRODS provider files";;
+    v)      VERBOSE=true ;;
+    ?)      USAGE=true && echo "Invalid option provided";;
+  esac
+done
+
+for var in "$@"
+do
+    if [[ "${var}" = 'run_irods' ]]; then
+        RUN_IRODS=true
+    fi
+done
+
+if $RUN_IRODS; then
+    if $USAGE; then
+        _usage
+    fi
+    if $INIT; then
+        _postgresql_tgz
+        _irods_tgz
+        _update_uid_gid
+        _set_postgres_params
+        ./postgres-docker-entrypoint.sh postgres &
+        while ! pg_isready
+        do
+            echo "$(date) - waiting for database to start"
+            sleep 2s
+        done
+        sleep 2s
+        _generate_config
+        gosu root /var/lib/irods/packaging/setup_irods.sh < /irods.config
+        _update_uid_gid
+        if $VERBOSE; then
+            echo "INFO: show ienv"
+            gosu irods ienv
+        fi
+        gosu root tail -f /dev/null
+    fi
+    if $EXISTING; then
+        _update_uid_gid
+        gosu postgres postgres &
+        while ! pg_isready; do
+            echo "$(date) - waiting for database to start"
+            sleep 2s
+        done
+        gosu root service irods start
+        gosu root tail -f /dev/null
+    fi
+else
+    if $USAGE; then
+        _usage
+    fi
+    _set_postgres_params
+    _update_uid_gid
+    exec "$@"
+fi
+
+exit 0;

--- a/4.1.11/Dockerfile
+++ b/4.1.11/Dockerfile
@@ -1,0 +1,75 @@
+FROM postgres:9.6
+MAINTAINER Michael J. Stealey <michael.j.stealey@gmail.com>
+
+# set user/group IDs for irods account
+RUN groupadd -r irods --gid=998 \
+    && useradd -r -g irods -d /var/lib/irods --uid=998 irods \
+    && mv /docker-entrypoint.sh /postgres-docker-entrypoint.sh
+
+# Prerequisites for iRODS v.4.1.11
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    sudo \
+    curl \
+    libfuse2 \
+    libjson-perl \
+    python-psutil \
+    python-requests \
+    lsof \
+    python-jsonschema \
+    unixodbc \
+    odbc-postgresql \
+    super \
+    jq
+
+# Install iRODS v.4.1.11
+RUN curl ftp://ftp.renci.org/pub/irods/releases/4.1.11/ubuntu14/irods-icat-4.1.11-ubuntu14-x86_64.deb -o irods-icat.deb \
+    && curl ftp://ftp.renci.org/pub/irods/releases/4.1.11/ubuntu14/irods-database-plugin-postgres-1.11-ubuntu14-x86_64.deb -o irods-database.deb \
+    && sudo dpkg -i irods-icat.deb irods-database.deb \
+    && sudo apt-get -f install \
+    && rm irods-icat.deb irods-database.deb
+
+# default iRODS env
+ENV IRODS_SERVICE_ACCOUNT_NAME=irods
+ENV IRODS_SERVICE_ACCOUNT_GROUP=irods
+ENV IRODS_DATABASE_SERVER_HOSTNAME=localhost
+ENV IRODS_DATABASE_SERVER_PORT=5432
+ENV IRODS_DATABASE_NAME=ICAT
+ENV IRODS_DATABASE_USER_NAME=irods
+ENV IRODS_DATABASE_PASSWORD=temppassword
+ENV IRODS_ZONE_NAME=tempZone
+ENV IRODS_PORT=1247
+ENV IRODS_PORT_RANGE_BEGIN=20000
+ENV IRODS_PORT_RANGE_END=20199
+ENV IRODS_CONTROL_PLANE_PORT=1248
+ENV IRODS_SCHEMA_VALIDATION=https://schemas.irods.org/configuration
+ENV IRODS_SERVER_ADMINISTRATOR_USER_NAME=rods
+ENV IRODS_SERVER_ZONE_KEY=TEMPORARY_zone_key
+ENV IRODS_SERVER_NEGOTIATION_KEY=TEMPORARY_32byte_negotiation_key
+ENV IRODS_CONTROL_PLANE_KEY=TEMPORARY__32byte_ctrl_plane_key
+ENV IRODS_SERVER_ADMINISTRATOR_PASSWORD=rods
+ENV IRODS_VAULT_DIRECTORY=/var/lib/irods/iRODS/Vault
+# UID / GID settings
+ENV UID_POSTGRES=999
+ENV GID_POSTGRES=999
+ENV UID_IRODS=998
+ENV GID_IRODS=998
+
+# create postgresql.tar.gz
+RUN cd /var/lib/postgresql/data \
+    && tar -czvf /postgresql.tar.gz . \
+    && cd /
+
+# create irods.tar.gz
+RUN cd /var/lib/irods \
+    && tar -czvf /irods.tar.gz . \
+    && cd /
+
+COPY ./docker-entrypoint.sh /irods-docker-entrypoint.sh
+VOLUME /var/lib/irods /etc/irods /var/lib/postgresql/data
+
+EXPOSE $IRODS_PORT $IRODS_CONTROL_PLANE_PORT $IRODS_PORT_RANGE_BEGIN-$IRODS_PORT_RANGE_END
+ENTRYPOINT ["/irods-docker-entrypoint.sh"]
+WORKDIR "/var/lib/irods"
+
+CMD ["-i", "run_irods"]

--- a/4.1.11/docker-entrypoint.sh
+++ b/4.1.11/docker-entrypoint.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -e
+
+IRODS_CONFIG_FILE=/irods.config
+INIT=false
+EXISTING=false
+USAGE=false
+VERBOSE=false
+RUN_IRODS=false
+
+_update_uid_gid() {
+    # if UID_POSTGRES = UID_IRODS, exit with error message
+    if [[ ${UID_POSTGRES} = ${UID_IRODS} ]]; then
+        echo "ERROR: user irods and user postgres cannot have same UID!!!"
+        exit 1;
+    else
+    # if UID_POSTGRES != UID_IRODS, reassign individual UIDs
+        if [[ ${UID_IRODS} = 999 ]]; then
+            gosu root usermod -u 1999 irods
+        fi
+        gosu root usermod -u ${UID_POSTGRES} postgres
+        gosu root usermod -u ${UID_IRODS} irods
+    fi
+    # if GID_POSTGRES = GID_IRODS, reset GID_POSTGRES=GID_IRODS-1 and use GID_IRODS group permissions
+    if [[ ${GID_POSTGRES} = ${GID_IRODS} ]]; then
+        gosu root groupmod -g ${GID_IRODS} irods
+        gosu root usermod -a -G ${GID_IRODS} postgres
+        gosu root chown -R postgres:irods /var/lib/postgresql
+        gosu root chown -R irods:irods /var/lib/irods
+        gosu root chown -R irods:irods /etc/irods
+    else
+    # if GID_POSTGRES != GID_IRODS, reassign individual GIDs
+        if [[ ${GID_IRODS} = 999 ]]; then
+            gosu root groupmod -g 1999 irods
+        fi
+        gosu root groupmod -g ${GID_POSTGRES} postgres
+        gosu root groupmod -g ${GID_IRODS} irods
+        gosu root chown -R postgres:postgres /var/lib/postgresql
+        gosu root chown -R irods:irods /var/lib/irods
+        gosu root chown -R irods:irods /etc/irods
+     fi
+}
+
+_set_postgres_params() {
+    # set postgres-docker-entrypoint.sh variables to coincide with iRODS variables unless explicitly defined
+    if [[ -z "${POSTGRES_PASSWORD}" ]]; then
+        gosu root sed -i 's/POSTGRES_PASSWORD/IRODS_DATABASE_PASSWORD/g' /postgres-docker-entrypoint.sh
+    fi
+    if [[ -z "${POSTGRES_USER}" ]]; then
+        gosu root sed -i 's/POSTGRES_USER/IRODS_DATABASE_USER_NAME/g' /postgres-docker-entrypoint.sh
+    fi
+    if [[ -z "${POSTGRES_DB}" ]]; then
+        gosu root sed -i 's/POSTGRES_DB/IRODS_DATABASE_NAME/g' /postgres-docker-entrypoint.sh
+    fi
+}
+
+_postgresql_tgz() {
+    if [ -z "$(ls -A /var/lib/postgresql/data)" ]; then
+        gosu root cp /postgresql.tar.gz /var/lib/postgresql/data/postgresql.tar.gz
+        cd /var/lib/postgresql/data
+        if $VERBOSE; then
+            echo "!!! populating /var/lib/postgresql/data with initial contents !!!"
+            gosu root tar -zxvf postgresql.tar.gz
+        else
+            gosu root tar -zxf postgresql.tar.gz
+        fi
+        cd /
+        gosu root rm -f /var/lib/postgresql/data/postgresql.tar.gz
+    fi
+}
+
+_irods_tgz() {
+    if [ -z "$(ls -A /var/lib/irods)" ]; then
+        gosu root cp /irods.tar.gz /var/lib/irods/irods.tar.gz
+        cd /var/lib/irods/
+        if $VERBOSE; then
+            echo "!!! populating /var/lib/irods with initial contents !!!"
+            gosu root tar -zxvf irods.tar.gz
+        else
+            gosu root tar -zxf irods.tar.gz
+        fi
+        cd /
+        gosu root rm -f /var/lib/irods/irods.tar.gz
+    fi
+}
+
+_generate_config() {
+    local OUTFILE=/irods.config
+    echo "${IRODS_SERVICE_ACCOUNT_NAME}" > $OUTFILE
+    echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> $OUTFILE
+    echo "${IRODS_ZONE_NAME}" >> $OUTFILE
+    echo "${IRODS_PORT}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_BEGIN}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_END}" >> $OUTFILE
+    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
+    echo "${IRODS_SERVER_ZONE_KEY}" >> $OUTFILE
+    echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_KEY}" >> $OUTFILE
+    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
+    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+}
+
+_usage() {
+    echo "Usage: ${0} [-h] [-ix run_irods] [-v] [arguments]"
+    echo " "
+    echo "options:"
+    echo "-h                    show brief help"
+    echo "-i run_irods          initialize iRODS 4.1.11 provider"
+    echo "-x run_irods          use existing iRODS 4.1.11 provider files"
+    echo "-v                    verbose output"
+    echo ""
+    echo "Example:"
+    echo "  $ docker run --rm mjstealey/irods-provider-postgres:4.1.11 -h           # show help"
+    echo "  $ docker run -d mjstealey/irods-provider-postgres:4.1.11 -i run_irods   # init with default settings"
+    echo ""
+    exit 0
+}
+
+while getopts hixv opt; do
+  case "${opt}" in
+    h)      USAGE=true ;;
+    i)      INIT=true && echo "Initialize iRODS provider";;
+    x)      EXISTING=true && echo "Use existing iRODS provider files";;
+    v)      VERBOSE=true ;;
+    ?)      USAGE=true && echo "Invalid option provided";;
+  esac
+done
+
+for var in "$@"
+do
+    if [[ "${var}" = 'run_irods' ]]; then
+        RUN_IRODS=true
+    fi
+done
+
+if $RUN_IRODS; then
+    if $USAGE; then
+        _usage
+    fi
+    if $INIT; then
+        _postgresql_tgz
+        _irods_tgz
+        _update_uid_gid
+        _set_postgres_params
+        ./postgres-docker-entrypoint.sh postgres &
+        while ! pg_isready
+        do
+            echo "$(date) - waiting for database to start"
+            sleep 2s
+        done
+        sleep 2s
+        _generate_config
+        gosu root /var/lib/irods/packaging/setup_irods.sh < /irods.config
+        _update_uid_gid
+        if $VERBOSE; then
+            echo "INFO: show ienv"
+            gosu irods ienv
+        fi
+        gosu root tail -f /dev/null
+    fi
+    if $EXISTING; then
+        _update_uid_gid
+        gosu postgres postgres &
+        while ! pg_isready; do
+            echo "$(date) - waiting for database to start"
+            sleep 2s
+        done
+        gosu root service irods start
+        gosu root tail -f /dev/null
+    fi
+else
+    if $USAGE; then
+        _usage
+    fi
+    _set_postgres_params
+    _update_uid_gid
+    exec "$@"
+fi
+
+exit 0;

--- a/4.1.8/Dockerfile
+++ b/4.1.8/Dockerfile
@@ -1,0 +1,75 @@
+FROM postgres:9.6
+MAINTAINER Michael J. Stealey <michael.j.stealey@gmail.com>
+
+# set user/group IDs for irods account
+RUN groupadd -r irods --gid=998 \
+    && useradd -r -g irods -d /var/lib/irods --uid=998 irods \
+    && mv /docker-entrypoint.sh /postgres-docker-entrypoint.sh
+
+# Prerequisites for iRODS v.4.1.8
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    sudo \
+    curl \
+    libfuse2 \
+    libjson-perl \
+    python-psutil \
+    python-requests \
+    lsof \
+    python-jsonschema \
+    unixodbc \
+    odbc-postgresql \
+    super \
+    jq
+
+# Install iRODS v.4.1.8
+RUN curl ftp://ftp.renci.org/pub/irods/releases/4.1.8/ubuntu14/irods-icat-4.1.8-ubuntu14-x86_64.deb -o irods-icat.deb \
+    && curl ftp://ftp.renci.org/pub/irods/releases/4.1.8/ubuntu14/irods-database-plugin-postgres-1.8-ubuntu14-x86_64.deb -o irods-database.deb \
+    && sudo dpkg -i irods-icat.deb irods-database.deb \
+    && sudo apt-get -f install \
+    && rm irods-icat.deb irods-database.deb
+
+# default iRODS env
+ENV IRODS_SERVICE_ACCOUNT_NAME=irods
+ENV IRODS_SERVICE_ACCOUNT_GROUP=irods
+ENV IRODS_DATABASE_SERVER_HOSTNAME=localhost
+ENV IRODS_DATABASE_SERVER_PORT=5432
+ENV IRODS_DATABASE_NAME=ICAT
+ENV IRODS_DATABASE_USER_NAME=irods
+ENV IRODS_DATABASE_PASSWORD=temppassword
+ENV IRODS_ZONE_NAME=tempZone
+ENV IRODS_PORT=1247
+ENV IRODS_PORT_RANGE_BEGIN=20000
+ENV IRODS_PORT_RANGE_END=20199
+ENV IRODS_CONTROL_PLANE_PORT=1248
+ENV IRODS_SCHEMA_VALIDATION=https://schemas.irods.org/configuration
+ENV IRODS_SERVER_ADMINISTRATOR_USER_NAME=rods
+ENV IRODS_SERVER_ZONE_KEY=TEMPORARY_zone_key
+ENV IRODS_SERVER_NEGOTIATION_KEY=TEMPORARY_32byte_negotiation_key
+ENV IRODS_CONTROL_PLANE_KEY=TEMPORARY__32byte_ctrl_plane_key
+ENV IRODS_SERVER_ADMINISTRATOR_PASSWORD=rods
+ENV IRODS_VAULT_DIRECTORY=/var/lib/irods/iRODS/Vault
+# UID / GID settings
+ENV UID_POSTGRES=999
+ENV GID_POSTGRES=999
+ENV UID_IRODS=998
+ENV GID_IRODS=998
+
+# create postgresql.tar.gz
+RUN cd /var/lib/postgresql/data \
+    && tar -czvf /postgresql.tar.gz . \
+    && cd /
+
+# create irods.tar.gz
+RUN cd /var/lib/irods \
+    && tar -czvf /irods.tar.gz . \
+    && cd /
+
+COPY ./docker-entrypoint.sh /irods-docker-entrypoint.sh
+VOLUME /var/lib/irods /etc/irods /var/lib/postgresql/data
+
+EXPOSE $IRODS_PORT $IRODS_CONTROL_PLANE_PORT $IRODS_PORT_RANGE_BEGIN-$IRODS_PORT_RANGE_END
+ENTRYPOINT ["/irods-docker-entrypoint.sh"]
+WORKDIR "/var/lib/irods"
+
+CMD ["-i", "run_irods"]

--- a/4.1.8/docker-entrypoint.sh
+++ b/4.1.8/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+IRODS_CONFIG_FILE=/irods.config
 INIT=false
 EXISTING=false
 USAGE=false
@@ -87,28 +88,25 @@ _generate_config() {
     local OUTFILE=/irods.config
     echo "${IRODS_SERVICE_ACCOUNT_NAME}" > $OUTFILE
     echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> $OUTFILE
-    echo "${IRODS_SERVER_ROLE}" >> $OUTFILE # 1. provider, 2. consumer
-    echo "${ODBC_DRIVER_FOR_POSTGRES}" >> $OUTFILE # 1. PostgreSQL ANSI, 2. PostgreSQL Unicode
-    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
-    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
-    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
-    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
-    echo "yes" >> $OUTFILE
-    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
-    echo "${IRODS_DATABASE_USER_PASSWORD_SALT}" >> $OUTFILE
     echo "${IRODS_ZONE_NAME}" >> $OUTFILE
     echo "${IRODS_PORT}" >> $OUTFILE
     echo "${IRODS_PORT_RANGE_BEGIN}" >> $OUTFILE
     echo "${IRODS_PORT_RANGE_END}" >> $OUTFILE
-    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
-    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
-    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
-    echo "yes" >> $OUTFILE
+    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
     echo "${IRODS_SERVER_ZONE_KEY}" >> $OUTFILE
     echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
     echo "${IRODS_CONTROL_PLANE_KEY}" >> $OUTFILE
+    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
     echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> $OUTFILE
-    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
+    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
 }
 
 _usage() {
@@ -116,13 +114,13 @@ _usage() {
     echo " "
     echo "options:"
     echo "-h                    show brief help"
-    echo "-i run_irods          initialize iRODS 4.2.1 provider"
-    echo "-x run_irods          use existing iRODS 4.2.1 provider files"
+    echo "-i run_irods          initialize iRODS 4.1.8 provider"
+    echo "-x run_irods          use existing iRODS 4.1.8 provider files"
     echo "-v                    verbose output"
     echo ""
     echo "Example:"
-    echo "  $ docker run --rm mjstealey/irods-provider-postgres:4.2.1 -h           # show help"
-    echo "  $ docker run -d mjstealey/irods-provider-postgres:4.2.1 -i run_irods   # init with default settings"
+    echo "  $ docker run --rm mjstealey/irods-provider-postgres:4.1.8 -h           # show help"
+    echo "  $ docker run -d mjstealey/irods-provider-postgres:4.1.8 -i run_irods   # init with default settings"
     echo ""
     exit 0
 }
@@ -161,7 +159,7 @@ if $RUN_IRODS; then
         done
         sleep 2s
         _generate_config
-        gosu root python /var/lib/irods/scripts/setup_irods.py < /irods.config
+        gosu root /var/lib/irods/packaging/setup_irods.sh < /irods.config
         _update_uid_gid
         if $VERBOSE; then
             echo "INFO: show ienv"

--- a/4.1.9/Dockerfile
+++ b/4.1.9/Dockerfile
@@ -1,0 +1,75 @@
+FROM postgres:9.6
+MAINTAINER Michael J. Stealey <michael.j.stealey@gmail.com>
+
+# set user/group IDs for irods account
+RUN groupadd -r irods --gid=998 \
+    && useradd -r -g irods -d /var/lib/irods --uid=998 irods \
+    && mv /docker-entrypoint.sh /postgres-docker-entrypoint.sh
+
+# Prerequisites for iRODS v.4.1.9
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    sudo \
+    curl \
+    libfuse2 \
+    libjson-perl \
+    python-psutil \
+    python-requests \
+    lsof \
+    python-jsonschema \
+    unixodbc \
+    odbc-postgresql \
+    super \
+    jq
+
+# Install iRODS v.4.1.9
+RUN curl ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icat-4.1.9-ubuntu14-x86_64.deb -o irods-icat.deb \
+    && curl ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-database-plugin-postgres-1.9-ubuntu14-x86_64.deb -o irods-database.deb \
+    && sudo dpkg -i irods-icat.deb irods-database.deb \
+    && sudo apt-get -f install \
+    && rm irods-icat.deb irods-database.deb
+
+# default iRODS env
+ENV IRODS_SERVICE_ACCOUNT_NAME=irods
+ENV IRODS_SERVICE_ACCOUNT_GROUP=irods
+ENV IRODS_DATABASE_SERVER_HOSTNAME=localhost
+ENV IRODS_DATABASE_SERVER_PORT=5432
+ENV IRODS_DATABASE_NAME=ICAT
+ENV IRODS_DATABASE_USER_NAME=irods
+ENV IRODS_DATABASE_PASSWORD=temppassword
+ENV IRODS_ZONE_NAME=tempZone
+ENV IRODS_PORT=1247
+ENV IRODS_PORT_RANGE_BEGIN=20000
+ENV IRODS_PORT_RANGE_END=20199
+ENV IRODS_CONTROL_PLANE_PORT=1248
+ENV IRODS_SCHEMA_VALIDATION=https://schemas.irods.org/configuration
+ENV IRODS_SERVER_ADMINISTRATOR_USER_NAME=rods
+ENV IRODS_SERVER_ZONE_KEY=TEMPORARY_zone_key
+ENV IRODS_SERVER_NEGOTIATION_KEY=TEMPORARY_32byte_negotiation_key
+ENV IRODS_CONTROL_PLANE_KEY=TEMPORARY__32byte_ctrl_plane_key
+ENV IRODS_SERVER_ADMINISTRATOR_PASSWORD=rods
+ENV IRODS_VAULT_DIRECTORY=/var/lib/irods/iRODS/Vault
+# UID / GID settings
+ENV UID_POSTGRES=999
+ENV GID_POSTGRES=999
+ENV UID_IRODS=998
+ENV GID_IRODS=998
+
+# create postgresql.tar.gz
+RUN cd /var/lib/postgresql/data \
+    && tar -czvf /postgresql.tar.gz . \
+    && cd /
+
+# create irods.tar.gz
+RUN cd /var/lib/irods \
+    && tar -czvf /irods.tar.gz . \
+    && cd /
+
+COPY ./docker-entrypoint.sh /irods-docker-entrypoint.sh
+VOLUME /var/lib/irods /etc/irods /var/lib/postgresql/data
+
+EXPOSE $IRODS_PORT $IRODS_CONTROL_PLANE_PORT $IRODS_PORT_RANGE_BEGIN-$IRODS_PORT_RANGE_END
+ENTRYPOINT ["/irods-docker-entrypoint.sh"]
+WORKDIR "/var/lib/irods"
+
+CMD ["-i", "run_irods"]

--- a/4.1.9/docker-entrypoint.sh
+++ b/4.1.9/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+IRODS_CONFIG_FILE=/irods.config
 INIT=false
 EXISTING=false
 USAGE=false
@@ -87,28 +88,25 @@ _generate_config() {
     local OUTFILE=/irods.config
     echo "${IRODS_SERVICE_ACCOUNT_NAME}" > $OUTFILE
     echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> $OUTFILE
-    echo "${IRODS_SERVER_ROLE}" >> $OUTFILE # 1. provider, 2. consumer
-    echo "${ODBC_DRIVER_FOR_POSTGRES}" >> $OUTFILE # 1. PostgreSQL ANSI, 2. PostgreSQL Unicode
-    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
-    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
-    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
-    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
-    echo "yes" >> $OUTFILE
-    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
-    echo "${IRODS_DATABASE_USER_PASSWORD_SALT}" >> $OUTFILE
     echo "${IRODS_ZONE_NAME}" >> $OUTFILE
     echo "${IRODS_PORT}" >> $OUTFILE
     echo "${IRODS_PORT_RANGE_BEGIN}" >> $OUTFILE
     echo "${IRODS_PORT_RANGE_END}" >> $OUTFILE
-    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
-    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
-    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
-    echo "yes" >> $OUTFILE
+    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
     echo "${IRODS_SERVER_ZONE_KEY}" >> $OUTFILE
     echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
     echo "${IRODS_CONTROL_PLANE_KEY}" >> $OUTFILE
+    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
     echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> $OUTFILE
-    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
+    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
 }
 
 _usage() {
@@ -116,13 +114,13 @@ _usage() {
     echo " "
     echo "options:"
     echo "-h                    show brief help"
-    echo "-i run_irods          initialize iRODS 4.2.1 provider"
-    echo "-x run_irods          use existing iRODS 4.2.1 provider files"
+    echo "-i run_irods          initialize iRODS 4.1.9 provider"
+    echo "-x run_irods          use existing iRODS 4.1.9 provider files"
     echo "-v                    verbose output"
     echo ""
     echo "Example:"
-    echo "  $ docker run --rm mjstealey/irods-provider-postgres:4.2.1 -h           # show help"
-    echo "  $ docker run -d mjstealey/irods-provider-postgres:4.2.1 -i run_irods   # init with default settings"
+    echo "  $ docker run --rm mjstealey/irods-provider-postgres:4.1.9 -h           # show help"
+    echo "  $ docker run -d mjstealey/irods-provider-postgres:4.1.9 -i run_irods   # init with default settings"
     echo ""
     exit 0
 }
@@ -161,7 +159,7 @@ if $RUN_IRODS; then
         done
         sleep 2s
         _generate_config
-        gosu root python /var/lib/irods/scripts/setup_irods.py < /irods.config
+        gosu root /var/lib/irods/packaging/setup_irods.sh < /irods.config
         _update_uid_gid
         if $VERBOSE; then
             echo "INFO: show ienv"

--- a/4.2.0/docker-entrypoint.sh
+++ b/4.2.0/docker-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-IRODS_CONFIG_FILE=/irods.config
 INIT=false
 EXISTING=false
 USAGE=false
@@ -85,36 +84,36 @@ _irods_tgz() {
 }
 
 _generate_config() {
-    DATABASE_HOSTNAME_OR_IP=$(/sbin/ip -f inet -4 -o addr | grep eth | cut -d '/' -f 1 | rev | cut -d ' ' -f 1 | rev)
-    echo "${IRODS_SERVICE_ACCOUNT_NAME}" > ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ROLE}" >> ${IRODS_CONFIG_FILE} # 1. provider, 2. consumer
-    echo "${ODBC_DRIVER_FOR_POSTGRES}" >> ${IRODS_CONFIG_FILE} # 1. PostgreSQL ANSI, 2. PostgreSQL Unicode
-    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_SERVER_PORT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_USER_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "yes" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_PASSWORD}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_USER_PASSWORD_SALT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_ZONE_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_PORT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_PORT_RANGE_BEGIN}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_PORT_RANGE_END}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_CONTROL_PLANE_PORT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SCHEMA_VALIDATION}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "yes" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ZONE_KEY}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_CONTROL_PLANE_KEY}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_VAULT_DIRECTORY}" >> ${IRODS_CONFIG_FILE}
+    local OUTFILE=/irods.config
+    echo "${IRODS_SERVICE_ACCOUNT_NAME}" > $OUTFILE
+    echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> $OUTFILE
+    echo "${IRODS_SERVER_ROLE}" >> $OUTFILE # 1. provider, 2. consumer
+    echo "${ODBC_DRIVER_FOR_POSTGRES}" >> $OUTFILE # 1. PostgreSQL ANSI, 2. PostgreSQL Unicode
+    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
+    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_PASSWORD_SALT}" >> $OUTFILE
+    echo "${IRODS_ZONE_NAME}" >> $OUTFILE
+    echo "${IRODS_PORT}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_BEGIN}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_END}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
+    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_SERVER_ZONE_KEY}" >> $OUTFILE
+    echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_KEY}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> $OUTFILE
+    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
 }
 
 _usage() {
     echo "Usage: ${0} [-h] [-ix run_irods] [-v] [arguments]"
-    echo " "
+    echo ""
     echo "options:"
     echo "-h                    show brief help"
     echo "-i run_irods          initialize iRODS 4.2.0 provider"
@@ -162,7 +161,7 @@ if $RUN_IRODS; then
         done
         sleep 2s
         _generate_config
-        gosu root python /var/lib/irods/scripts/setup_irods.py < ${IRODS_CONFIG_FILE}
+        gosu root python /var/lib/irods/scripts/setup_irods.py < /irods.config
         _update_uid_gid
         if $VERBOSE; then
             echo "INFO: show ienv"

--- a/4.2.2/docker-entrypoint.sh
+++ b/4.2.2/docker-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-IRODS_CONFIG_FILE=/irods.config
 INIT=false
 EXISTING=false
 USAGE=false
@@ -85,31 +84,31 @@ _irods_tgz() {
 }
 
 _generate_config() {
-    DATABASE_HOSTNAME_OR_IP=$(/sbin/ip -f inet -4 -o addr | grep eth | cut -d '/' -f 1 | rev | cut -d ' ' -f 1 | rev)
-    echo "${IRODS_SERVICE_ACCOUNT_NAME}" > ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ROLE}" >> ${IRODS_CONFIG_FILE} # 1. provider, 2. consumer
-    echo "${ODBC_DRIVER_FOR_POSTGRES}" >> ${IRODS_CONFIG_FILE} # 1. PostgreSQL ANSI, 2. PostgreSQL Unicode
-    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_SERVER_PORT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_USER_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "yes" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_PASSWORD}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_DATABASE_USER_PASSWORD_SALT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_ZONE_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_PORT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_PORT_RANGE_BEGIN}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_PORT_RANGE_END}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_CONTROL_PLANE_PORT}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SCHEMA_VALIDATION}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> ${IRODS_CONFIG_FILE}
-    echo "yes" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ZONE_KEY}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_CONTROL_PLANE_KEY}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> ${IRODS_CONFIG_FILE}
-    echo "${IRODS_VAULT_DIRECTORY}" >> ${IRODS_CONFIG_FILE}
+    local OUTFILE=/irods.config
+    echo "${IRODS_SERVICE_ACCOUNT_NAME}" > $OUTFILE
+    echo "${IRODS_SERVICE_ACCOUNT_GROUP}" >> $OUTFILE
+    echo "${IRODS_SERVER_ROLE}" >> $OUTFILE # 1. provider, 2. consumer
+    echo "${ODBC_DRIVER_FOR_POSTGRES}" >> $OUTFILE # 1. PostgreSQL ANSI, 2. PostgreSQL Unicode
+    echo "${IRODS_DATABASE_SERVER_HOSTNAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_SERVER_PORT}" >> $OUTFILE
+    echo "${IRODS_DATABASE_NAME}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_NAME}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_DATABASE_PASSWORD}" >> $OUTFILE
+    echo "${IRODS_DATABASE_USER_PASSWORD_SALT}" >> $OUTFILE
+    echo "${IRODS_ZONE_NAME}" >> $OUTFILE
+    echo "${IRODS_PORT}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_BEGIN}" >> $OUTFILE
+    echo "${IRODS_PORT_RANGE_END}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_PORT}" >> $OUTFILE
+    echo "${IRODS_SCHEMA_VALIDATION}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_USER_NAME}" >> $OUTFILE
+    echo "yes" >> $OUTFILE
+    echo "${IRODS_SERVER_ZONE_KEY}" >> $OUTFILE
+    echo "${IRODS_SERVER_NEGOTIATION_KEY}" >> $OUTFILE
+    echo "${IRODS_CONTROL_PLANE_KEY}" >> $OUTFILE
+    echo "${IRODS_SERVER_ADMINISTRATOR_PASSWORD}" >> $OUTFILE
+    echo "${IRODS_VAULT_DIRECTORY}" >> $OUTFILE
 }
 
 _usage() {
@@ -162,7 +161,7 @@ if $RUN_IRODS; then
         done
         sleep 2s
         _generate_config
-        gosu root python /var/lib/irods/scripts/setup_irods.py < ${IRODS_CONFIG_FILE}
+        gosu root python /var/lib/irods/scripts/setup_irods.py < /irods.config
         _update_uid_gid
         if $VERBOSE; then
             echo "INFO: show ienv"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 iRODS provider in Docker
 
-- v4.2.2 - Debian:stretch based using PostgreSQL 10 (16.04 Xenial iRODS packages)
-- v4.2.1 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS packages)
-- v4.2.0 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS packages)
+- 4.2.2 - Debian:stretch based using PostgreSQL 10 (16.04 Xenial iRODS packages)
+- 4.2.1 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS packages)
+- 4.2.0 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS packages)
+- 4.1.11 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)
+- 4.1.10 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)
+- 4.1.9 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)
+- 4.1.8 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)
 
 Jump to [Real world usage](#real_usage) example
 
@@ -13,6 +17,10 @@ Jump to [Real world usage](#real_usage) example
 - 4.2.2, latest ([4.2.2/Dockerfile](https://github.com/mjstealey/irods-provider-postgres/blob/master/4.2.2/Dockerfile))
 - 4.2.1 ([4.2.1/Dockerfile](https://github.com/mjstealey/irods-provider-postgres/blob/master/4.2.1/Dockerfile))
 - 4.2.0 ([4.2.0/Dockerfile](https://github.com/mjstealey/irods-provider-postgres/blob/master/4.2.0/Dockerfile))
+- 4.1.11 ([4.1.11/Dockerfile](https://github.com/mjstealey/irods-provider-postgres/blob/master/4.1.11/Dockerfile))
+- 4.1.10 ([4.1.10/Dockerfile](https://github.com/mjstealey/irods-provider-postgres/blob/master/4.1.10/Dockerfile))
+- 4.1.9 ([4.1.9/Dockerfile](https://github.com/mjstealey/irods-provider-postgres/blob/master/4.1.9/Dockerfile))
+- 4.1.8 ([4.1.8/Dockerfile](https://github.com/mjstealey/irods-provider-postgres/blob/master/4.1.8/Dockerfile))
 
 ### Pull image from dockerhub
 
@@ -105,6 +113,10 @@ GID_POSTGRES=999
 UID_IRODS=998
 GID_IRODS=998
 ```
+
+- **Note**: For iRODS 4.1.x there is no need to specify `IRODS_SERVER_ROLE`, `ODBC_DRIVER_FOR_POSTGRES` or `IRODS_DATABASE_USER_PASSWORD_SALT`. If specified the values will be ignored as they are not used by the 4.1.x setup scripts.
+
+
 Interaction with the iRODS server can be done with the `docker exec` command. The container has a definition of the `irods` Linux service account that has been associated with the `rods` **rodsadmin** user in iRODS. Interaction would look as follows:
 
 - Sample **ils**:
@@ -281,6 +293,9 @@ GID_POSTGRES=999
 UID_IRODS=998
 GID_IRODS=998
 ```
+
+- **Note**: For iRODS 4.1.x there is no need to specify `IRODS_SERVER_ROLE`, `ODBC_DRIVER_FOR_POSTGRES` or `IRODS_DATABASE_USER_PASSWORD_SALT`. If specified the values will be ignored as they are not used by the 4.1.x setup scripts.
+
 This can be particularly useful if you want shared volume mounts to be written to the host using a particular `UID` or `GID` value to better integrate with the system.
 
 The inclusion of an environment file is made by adding `--env-file=FILENAME` to the `docker run` call.


### PR DESCRIPTION
Revise builds for 4.1.x versions back to 4.1.8 and include here per #8 
- 4.1.11 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)
- 4.1.10 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)
- 4.1.9 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)
- 4.1.8 - Debian:jessie based using PostgreSQL 9.6 (14.04 Trusty iRODS ftp deb files)